### PR TITLE
Fix S4 method signatures to really use parallel computing on rangeMap.save

### DIFF
--- a/tests/testthat/test-4_save.R
+++ b/tests/testthat/test-4_save.R
@@ -20,11 +20,24 @@ rangeMap.save(con, biotab = "biotab", biotrait = "body_mass",
 
 test_that("rangeMap.save works in parallel", {
 
-rangeMap.save(con, biotab = "biotab", biotrait = "body_mass", cl = 2,
+cl<- parallel::makeCluster(parallel::detectCores())
+
+# Non parallel for SQL function
+rangeMap.save(con, biotab = "biotab", biotrait = "body_mass", cl = cl,
     tableName = "x", FUN = "avg", overwrite = TRUE)
 
-rangeMap.save(con, biotab = "biotab", biotrait = "body_mass", cl = 2,
-    tableName = "x", FUN = mean, na.rm = TRUE, overwrite = TRUE)
+slowMean<- function(x, ...){
+  Sys.sleep(1)
+  mean(x, ...)
+}
 
+parTime<- system.time(rangeMap.save(con, biotab = "biotab", biotrait = "body_mass", cl = cl,
+    tableName = "x", FUN = slowMean, na.rm = TRUE, overwrite = TRUE))
+Time<- system.time(rangeMap.save(con, biotab = "biotab", biotrait = "body_mass",
+    tableName = "x", FUN = slowMean, na.rm = TRUE, overwrite = TRUE))
 
+parallel::stopCluster(cl)
+
+diffT<- parTime - Time
+expect_less_than(diffT["elapsed"], 0)
     })


### PR DESCRIPTION
Risky test, it depends on the number of available cores and the parallel time overhead. It's possible to relax the test by avoiding checking that parallel is faster than single core runs.